### PR TITLE
Fix: yaml width

### DIFF
--- a/python/cli/cms_config.py
+++ b/python/cli/cms_config.py
@@ -25,6 +25,7 @@ CONFIG_FILE = current_work_dir + "/cms/cli.yaml"
 yaml = YAML()
 yaml.preserve_quotes = True
 yaml.indent(mapping=2, sequence=4, offset=2)
+yaml.width = 40960
 
 
 def restore_config(cfg: dict):

--- a/python/sdc/util/file.py
+++ b/python/sdc/util/file.py
@@ -20,6 +20,7 @@ from ruamel.yaml import YAML
 yaml = YAML()
 yaml.preserve_quotes = True
 yaml.indent(mapping=2, sequence=4, offset=2)
+yaml.width = 40960
 
 
 def read_file(file_path: str, mode: str):


### PR DESCRIPTION
Avoid auto line wrap when writing cert pem strings. It may cause cert format err.