### PR TITLE
fix: sdc util, avoid circular import

### DIFF
--- a/python/sdc/util/crypto.py
+++ b/python/sdc/util/crypto.py
@@ -24,7 +24,13 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 from sdc.crypto import symm
 from sdc.util import constants
-from sdc.util.tool import bytes2int
+
+
+def bytes2int(buf: bytes):
+    res = 0
+    for index in range(len(buf)):
+        res = res << 8 | buf[len(buf) - index - 1]
+    return res
 
 
 def hmac_sha256(key: bytes, *args: bytes) -> bytes:

--- a/python/sdc/util/tool.py
+++ b/python/sdc/util/tool.py
@@ -27,13 +27,6 @@ def assert_list_len_equal(
         assert len(l1) == len(l2), msg
 
 
-def bytes2int(buf: bytes):
-    res = 0
-    for index in range(len(buf)):
-        res = res << 8 | buf[len(buf) - index - 1]
-    return res
-
-
 def to_hex(data: bytes):
     return "".join("{:02x}".format(x) for x in data)
 


### PR DESCRIPTION
sdc.util.tool import sdc.util.crypto

and sdc.util.crypto import sdc.util.tool.bytes2int

fix above circular import